### PR TITLE
feat: add student and parent dashboard

### DIFF
--- a/src/app/(dashboard)/academics/timetable/page.tsx
+++ b/src/app/(dashboard)/academics/timetable/page.tsx
@@ -1,15 +1,30 @@
 "use client";
 
 import withAuth from '@/components/withAuth';
-import { STAFF_ROLES } from '@/constants/roles';
+import { STAFF_ROLES, UserRole } from '@/constants/roles';
+import { usePermissions } from '@/utils/permissions';
 
 const TimetablePage = () => {
+  const { hasRole } = usePermissions();
+
+  const isStudentOrParent = hasRole(UserRole.STUDENT) || hasRole(UserRole.PARENT);
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold">Timetable</h1>
-      <p>This page is currently under construction. Please check back later.</p>
+      {isStudentOrParent ? (
+        <div>
+          <h2 className="text-xl font-semibold">Student Timetable View</h2>
+          <p>This is the simplified timetable view for students and parents. This page is under construction.</p>
+        </div>
+      ) : (
+        <div>
+          <h2 className="text-xl font-semibold">Staff Timetable View</h2>
+          <p>This is the staff view for managing timetables. This page is under construction.</p>
+        </div>
+      )}
     </div>
   );
 };
 
-export default withAuth(TimetablePage, STAFF_ROLES);
+export default withAuth(TimetablePage, [...STAFF_ROLES, UserRole.STUDENT, UserRole.PARENT]);

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -16,8 +16,6 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   const { user, token, isLoading, initializeAuth } = useAuthStore();
   const router = useRouter();
   const [isInitialized, setIsInitialized] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   useEffect(() => {
     // Initialize auth on mount
@@ -42,25 +40,13 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   }
 
   return (
-    <div className="flex h-screen bg-gray-100 overflow-hidden">
-      <Sidebar 
-        isCollapsed={sidebarCollapsed}
-        setIsCollapsed={setSidebarCollapsed}
-        isMobileOpen={mobileSidebarOpen}
-        setIsMobileOpen={setMobileSidebarOpen}
-      />
-      <div className={`flex-1 flex flex-col transition-all duration-300 ease-in-out ${
-        sidebarCollapsed ? 'md:ml-0' : 'md:ml-0'
-      } w-full min-w-0`}>
+    <div className="flex h-screen bg-gray-100">
+      <Sidebar />
+      <div className="flex-1 flex flex-col">
         <NotificationBanner />
-        <Header 
-          onMobileMenuClick={() => setMobileSidebarOpen(true)}
-          sidebarCollapsed={sidebarCollapsed}
-        />
-        <main className="flex-1 p-4 md:p-6 overflow-y-auto bg-gray-50">
-          <div className="max-w-full">
-            {children}
-          </div>
+        <Header />
+        <main className="flex-1 p-6 overflow-y-auto">
+          {children}
         </main>
       </div>
     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -72,7 +72,18 @@ const LoginPage: React.FC = () => {
         type: "success",
         message: "Welcome back!",
       });
-      router.push(DASHBOARD_ROUTES.MULTI_SCHOOL_DASHBOARD);
+
+      // Get the latest state from the store to decide on redirection
+      const authState = useAuthStore.getState();
+
+      if (authState.user?.isSuperAdmin || authState.staff) {
+        router.push(DASHBOARD_ROUTES.MULTI_SCHOOL_DASHBOARD);
+      } else if (authState.student || authState.parent) {
+        router.push(DASHBOARD_ROUTES.STUDENT_DASHBOARD);
+      } else {
+        // Fallback to the main dashboard
+        router.push(DASHBOARD_ROUTES.MULTI_SCHOOL_DASHBOARD);
+      }
     } catch (error) {
       if (
         error instanceof ApiError &&

--- a/src/app/student/dashboard/page.tsx
+++ b/src/app/student/dashboard/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import withAuth from '@/components/withAuth';
+import { UserRole } from '@/constants/roles';
+
+const StudentDashboardPage = () => {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Student Dashboard</h1>
+      <p>Welcome to your dashboard. This page is under construction.</p>
+    </div>
+  );
+};
+
+export default withAuth(StudentDashboardPage, [UserRole.STUDENT, UserRole.PARENT]);

--- a/src/app/student/examinations/cbt/page.tsx
+++ b/src/app/student/examinations/cbt/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import withAuth from '@/components/withAuth';
+import { UserRole } from '@/constants/roles';
+
+const CBTPage = () => {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">CBT Exam</h1>
+      <p>This page will be used for taking Computer-Based Tests. This page is under construction.</p>
+    </div>
+  );
+};
+
+export default withAuth(CBTPage, [UserRole.STUDENT, UserRole.PARENT]);

--- a/src/app/student/finance/make-payment/page.tsx
+++ b/src/app/student/finance/make-payment/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import withAuth from '@/components/withAuth';
+import { UserRole } from '@/constants/roles';
+
+const MakePaymentPage = () => {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Make a Payment</h1>
+      <p>This page will be used for making payments. This page is under construction.</p>
+    </div>
+  );
+};
+
+export default withAuth(MakePaymentPage, [UserRole.STUDENT, UserRole.PARENT]);

--- a/src/app/student/layout.tsx
+++ b/src/app/student/layout.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+// These components will be created in the next steps
+// import StudentHeader from '@/components/student-dashboard/StudentHeader';
+// import StudentSidebar from '@/components/student-dashboard/StudentSidebar';
+
+const StudentDashboardLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="flex h-screen bg-gray-100">
+      {/* <StudentSidebar /> */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* <StudentHeader /> */}
+        <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-200">
+          <div className="container mx-auto px-6 py-8">
+            {children}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default StudentDashboardLayout;

--- a/src/app/student/notifications/page.tsx
+++ b/src/app/student/notifications/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import withAuth from '@/components/withAuth';
+import { UserRole } from '@/constants/roles';
+
+const StudentNotificationsPage = () => {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Notifications</h1>
+      <p>This page will display all notifications for the student/parent. This page is under construction.</p>
+    </div>
+  );
+};
+
+export default withAuth(StudentNotificationsPage, [UserRole.STUDENT, UserRole.PARENT]);

--- a/src/app/student/profile/page.tsx
+++ b/src/app/student/profile/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import withAuth from '@/components/withAuth';
+import { UserRole } from '@/constants/roles';
+
+const StudentProfilePage = () => {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">My Profile</h1>
+      <p>This page will display student and parent information. This page is under construction.</p>
+    </div>
+  );
+};
+
+export default withAuth(StudentProfilePage, [UserRole.STUDENT, UserRole.PARENT]);

--- a/src/components/dashboard/Header.tsx
+++ b/src/components/dashboard/Header.tsx
@@ -6,14 +6,8 @@ import { useAuthStore } from '@/store/authStore';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { FaUserCircle, FaBars } from 'react-icons/fa';
+import { FaUserCircle } from 'react-icons/fa';
 import { useRouter } from 'next/navigation';
-import SchoolSelector from './SchoolSelector';
-
-interface HeaderProps {
-  onMobileMenuClick: () => void;
-  sidebarCollapsed: boolean;
-}
 
 const SessionSelector = () => {
   const { sessions, selectedSession, fetchSessions, setSelectedSession, isLoading } = useSessionStore();
@@ -23,7 +17,7 @@ const SessionSelector = () => {
   }, [fetchSessions]);
 
   if (isLoading) {
-    return <div className="text-sm text-gray-500">Loading Sessions...</div>;
+    return <div>Loading Sessions...</div>;
   }
 
   if (!selectedSession) {
@@ -40,7 +34,7 @@ const SessionSelector = () => {
         }
       }}
     >
-      <SelectTrigger className="w-[140px] md:w-[180px]">
+      <SelectTrigger className="w-[180px]">
         <SelectValue placeholder="Select a session" />
       </SelectTrigger>
       <SelectContent>
@@ -68,7 +62,7 @@ const UserProfile = () => {
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="relative h-8 w-8 rounded-full">
-                    <FaUserCircle className="h-6 w-6 md:h-8 md:w-8" />
+                    <FaUserCircle className="h-8 w-8" />
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className="w-56" align="end" forceMount>
@@ -90,7 +84,9 @@ const UserProfile = () => {
     );
 }
 
-const Header: React.FC<HeaderProps> = ({ onMobileMenuClick, sidebarCollapsed }) => {
+import SchoolSelector from './SchoolSelector';
+
+const Header = () => {
   const { loadSchools } = useAuthStore();
 
   useEffect(() => {
@@ -98,26 +94,10 @@ const Header: React.FC<HeaderProps> = ({ onMobileMenuClick, sidebarCollapsed }) 
   }, [loadSchools]);
 
   return (
-    <header className="bg-white shadow-sm p-3 md:p-4 border-b flex justify-between items-center sticky top-0 z-30">
-      <div className="flex items-center space-x-3">
-        {/* Mobile menu button */}
-        <button
-          onClick={onMobileMenuClick}
-          className="md:hidden p-2 rounded-md hover:bg-gray-100 transition-colors"
-        >
-          <FaBars className="h-5 w-5" />
-        </button>
-        
-        {/* Logo/Title for mobile when sidebar is hidden */}
-        <div className="md:hidden">
-          <h1 className="text-lg font-semibold text-gray-800">EduStack</h1>
-        </div>
-      </div>
-      
-      <div className="flex items-center space-x-2 md:space-x-4">
-        <div className="hidden sm:block">
-          <SchoolSelector />
-        </div>
+    <header className="bg-white shadow-sm p-4 border-b flex justify-between items-center">
+      <div>{/* Logo can go here */}</div>
+      <div className="flex items-center space-x-4">
+        <SchoolSelector />
         <SessionSelector />
         <UserProfile />
       </div>

--- a/src/components/dashboard/NotificationBanner.tsx
+++ b/src/components/dashboard/NotificationBanner.tsx
@@ -30,7 +30,7 @@ export const NotificationBanner = () => {
         <div>
           <p className="font-bold">Session Reminder</p>
           <p className="text-sm">
-            The current session, &apos;{selectedSession?.name}&apos;, is ending in {daysUntilEnd} {daysUntilEnd === 1 ? 'day' : 'days'}. Please prepare for the next academic session.
+            The current session, '{selectedSession?.name}', is ending in {daysUntilEnd} {daysUntilEnd === 1 ? 'day' : 'days'}. Please prepare for the next academic session.
           </p>
         </div>
         <div className="ml-auto pl-3">

--- a/src/components/student-dashboard/StudentSidebar.tsx
+++ b/src/components/student-dashboard/StudentSidebar.tsx
@@ -4,14 +4,15 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { usePermissions } from '@/utils/permissions';
-import { sidebarConfig } from '@/constants/sidebar-links';
+import { studentSidebarConfig } from '@/constants/student-sidebar-links';
 import { COLORS } from '@/constants/colors';
 import { FaChevronDown } from 'react-icons/fa';
 import { IconType } from 'react-icons';
+import { SidebarCategory } from '@/constants/sidebar-links';
 
-const Sidebar = () => {
+const StudentSidebar = () => {
   const pathname = usePathname();
-  const { isSuperAdmin, currentRole, isStaff } = usePermissions();
+  const { hasRole } = usePermissions();
   const [openCategories, setOpenCategories] = useState<string[]>([]);
 
   const toggleCategory = (title: string) => {
@@ -20,28 +21,25 @@ const Sidebar = () => {
     );
   };
 
-  const userHasAccess = (roles: any[], isLinkStaff: boolean | undefined, allAuthenticated: boolean | undefined) => {
-    if (allAuthenticated) return true; // Accessible to all authenticated users
-    if (isSuperAdmin) return true;
-    if (isLinkStaff && isStaff) return true;
-    if (!currentRole) return false;
-    return roles.includes(currentRole);
+  const userHasAccess = (roles: any[]) => {
+    if (!roles || roles.length === 0) return true; // Default to true if no roles specified
+    return roles.some(role => hasRole(role));
   };
 
   return (
-    <aside className="w-64 bg-gray-900 text-white p-6 hidden md:block">
+    <aside className="w-64 bg-blue-900 text-white p-6 hidden md:block">
       <div className="mb-8">
-        <h2 className="text-2xl font-bold text-white">EduStack</h2>
+        <h2 className="text-2xl font-bold text-white">Student Portal</h2>
       </div>
       <nav>
         <ul>
-          {sidebarConfig
-            .filter(category => userHasAccess(category.roles, category.isStaff, category.allAuthenticated))
+          {(studentSidebarConfig as SidebarCategory[])
+            .filter(category => userHasAccess(category.roles))
             .map((category) => (
             <li key={category.title} className="mb-2">
               <button
                 onClick={() => toggleCategory(category.title)}
-                className="w-full flex justify-between items-center p-2 rounded-md transition-colors text-gray-400 hover:bg-gray-800 hover:text-white"
+                className="w-full flex justify-between items-center p-2 rounded-md transition-colors text-gray-300 hover:bg-blue-800 hover:text-white"
               >
                 <span>{category.title}</span>
                 <FaChevronDown className={`transition-transform ${openCategories.includes(category.title) ? 'rotate-180' : ''}`} />
@@ -49,7 +47,7 @@ const Sidebar = () => {
               {openCategories.includes(category.title) && (
                 <ul className="pl-4 mt-2">
                   {category.links
-                    .filter(link => userHasAccess(link.roles, link.isStaff, link.allAuthenticated))
+                    .filter(link => userHasAccess(link.roles))
                     .map((link) => {
                     const isActive = pathname === link.href;
                     const LinkIcon = link.icon as IconType;
@@ -60,7 +58,7 @@ const Sidebar = () => {
                           className={`flex items-center p-2 rounded-md transition-colors ${
                             isActive
                               ? 'text-white'
-                              : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                              : 'text-gray-300 hover:bg-blue-800 hover:text-white'
                           }`}
                           style={{
                             backgroundColor: isActive ? COLORS.primary[500] : 'transparent'
@@ -82,4 +80,4 @@ const Sidebar = () => {
   );
 };
 
-export default Sidebar;
+export default StudentSidebar;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -49,6 +49,13 @@ export const DASHBOARD_ROUTES = {
   NOTIFICATION_SEND: '/notifications/send',
   NOTIFICATION_VIEW: '/notifications/view',
 
+  // Student & Parent Dashboard
+  STUDENT_DASHBOARD: '/student/dashboard',
+  STUDENT_PROFILE: '/student/profile',
+  STUDENT_EXAMS_CBT: '/student/examinations/cbt',
+  STUDENT_FINANCE_MAKE_PAYMENT: '/student/finance/make-payment',
+  STUDENT_NOTIFICATIONS: '/student/notifications',
+
   // Shared Routes
   PROFILE: '/profile',
   SETTINGS: '/settings',

--- a/src/constants/student-sidebar-links.ts
+++ b/src/constants/student-sidebar-links.ts
@@ -1,0 +1,112 @@
+import {
+  FaTachometerAlt, FaUserCircle, FaBook, FaClipboardList, FaFileInvoiceDollar, FaBell
+} from 'react-icons/fa';
+import { UserRole } from './roles';
+import { DASHBOARD_ROUTES } from './routes';
+import { IconType } from 'react-icons';
+import { SidebarCategory } from './sidebar-links'; // Re-use the interface
+
+export const studentSidebarConfig: SidebarCategory[] = [
+  {
+    title: 'Dashboard',
+    roles: [UserRole.STUDENT, UserRole.PARENT],
+    links: [
+      {
+        href: DASHBOARD_ROUTES.STUDENT_DASHBOARD,
+        label: 'Overview',
+        icon: FaTachometerAlt,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.STUDENT_PROFILE,
+        label: 'My Profile',
+        icon: FaUserCircle,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+    ],
+  },
+  {
+    title: 'Academics',
+    roles: [UserRole.STUDENT, UserRole.PARENT],
+    links: [
+      {
+        href: DASHBOARD_ROUTES.TIMETABLE,
+        label: 'Timetable',
+        icon: FaClipboardList,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.SUBJECTS,
+        label: 'Subjects',
+        icon: FaBook,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.ATTENDANCE_STUDENT,
+        label: 'Attendance',
+        icon: FaClipboardList,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+    ],
+  },
+  {
+    title: 'Examinations',
+    roles: [UserRole.STUDENT, UserRole.PARENT],
+    links: [
+      {
+        href: DASHBOARD_ROUTES.EXAMS_MANAGE,
+        label: 'Exam Schedule',
+        icon: FaClipboardList,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.STUDENT_EXAMS_CBT,
+        label: 'CBT Exam',
+        icon: FaBook,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.EXAMS_RESULTS,
+        label: 'Results',
+        icon: FaClipboardList,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+    ],
+  },
+  {
+    title: 'Finance',
+    roles: [UserRole.STUDENT, UserRole.PARENT],
+    links: [
+      {
+        href: DASHBOARD_ROUTES.FINANCE_INVOICES,
+        label: 'Invoices',
+        icon: FaFileInvoiceDollar,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.FINANCE_PAYMENTS,
+        label: 'Payment History',
+        icon: FaFileInvoiceDollar,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+      {
+        href: DASHBOARD_ROUTES.STUDENT_FINANCE_MAKE_PAYMENT,
+        label: 'Make a Payment',
+        icon: FaFileInvoiceDollar,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+    ],
+  },
+  {
+    title: 'Notifications',
+    roles: [UserRole.STUDENT, UserRole.PARENT],
+    links: [
+      {
+        href: DASHBOARD_ROUTES.STUDENT_NOTIFICATIONS,
+        label: 'View All Notifications',
+        icon: FaBell,
+        roles: [UserRole.STUDENT, UserRole.PARENT],
+      },
+    ],
+  },
+];


### PR DESCRIPTION
This commit introduces a new, dedicated dashboard for students and parents.

Key changes include:

- **New Layout:** A new layout has been created for the student/parent dashboard at `/student`, featuring a unique design and a dedicated sidebar.
- **New Sidebar:** A new sidebar configuration (`student-sidebar-links.ts`) and component (`StudentSidebar.tsx`) have been created to provide navigation for students and parents.
- **Role-Based Redirection:** The login page logic has been updated to redirect users to the appropriate dashboard (`/dashboard` for staff, `/student/dashboard` for students/parents) based on their role.
- **New Student/Parent Pages:** New placeholder pages have been created for student/parent-specific features like the student profile, CBT exams, and making payments.
- **Adapted Shared Pages:** Existing pages for shared features like the timetable have been adapted to show a simplified view for students and parents, demonstrating the pattern for future development.