### PR TITLE
feat: Implement Subject Management UI

### DIFF
--- a/src/app/(dashboard)/academics/subjects/SubjectsList.tsx
+++ b/src/app/(dashboard)/academics/subjects/SubjectsList.tsx
@@ -1,0 +1,206 @@
+"use client";
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { MoreHorizontal } from 'lucide-react';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { subjectService, staffService, Subject, Teacher } from '@/services/subjectService';
+import { toast } from 'react-hot-toast';
+import { useAuthStore } from '@/store/authStore';
+import { UserRole } from '@/constants/roles';
+
+
+const SubjectsList = () => {
+  const router = useRouter();
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+  const [teachers, setTeachers] = useState<Teacher[]>([]);
+  const [selectedSubject, setSelectedSubject] = useState<Subject | null>(null);
+  const [selectedTeacher, setSelectedTeacher] = useState('');
+  const [isAssignTeacherDialogOpen, setIsAssignTeacherDialogOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { selectedSchool } = useAuthStore.getState();
+  const userRole = selectedSchool?.role;
+  const canManage = userRole === UserRole.SUPER_ADMIN || userRole === UserRole.ADMIN;
+
+  useEffect(() => {
+    const fetchSubjects = async () => {
+      try {
+        setLoading(true);
+        const response = await subjectService.getSubjects();
+        setSubjects(response.data);
+        setError(null);
+      } catch (error) {
+        toast.error('Failed to fetch subjects');
+        setError('Failed to fetch subjects');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    const fetchTeachers = async () => {
+        try {
+          const response = await staffService.getAllStaff();
+          const teacherList = response.data
+            .filter((staff: any) => staff.user.role === UserRole.TEACHER)
+            .map((staff: any) => ({ id: staff.id, name: staff.name }));
+          setTeachers(teacherList);
+        } catch (error) {
+          toast.error('Failed to fetch teachers');
+        }
+      };
+
+    fetchSubjects();
+    fetchTeachers();
+  }, []);
+
+  const handleAssignTeacher = (subject: Subject) => {
+    setSelectedSubject(subject);
+    setIsAssignTeacherDialogOpen(true);
+  };
+
+  const handleConfirmAssignTeacher = async () => {
+    if (!selectedSubject || !selectedTeacher) {
+      toast.error('Please select a teacher.');
+      return;
+    }
+    try {
+      await subjectService.assignTeacher(selectedSubject.id, selectedTeacher);
+      toast.success('Teacher assigned successfully');
+      setIsAssignTeacherDialogOpen(false);
+      // Refresh subjects list
+      const response = await subjectService.getSubjects();
+      setSubjects(response.data);
+    } catch (error) {
+      toast.error('Failed to assign teacher');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (window.confirm('Are you sure you want to delete this subject?')) {
+      try {
+        await subjectService.deleteSubject(id);
+        toast.success('Subject deleted successfully');
+        setSubjects(subjects.filter((s) => s.id !== id));
+      } catch (error) {
+        toast.error('Failed to delete subject');
+      }
+    }
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex justify-between items-center">
+          <CardTitle>Subjects</CardTitle>
+          {canManage && (
+            <Button onClick={() => router.push('/academics/subjects/create')}>
+              Add Subject
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Code</TableHead>
+              <TableHead>Class</TableHead>
+              <TableHead>Teacher</TableHead>
+              <TableHead>Status</TableHead>
+              {canManage && <TableHead>Actions</TableHead>}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {subjects.map((subject) => (
+              <TableRow key={subject.id}>
+                <TableCell>{subject.name}</TableCell>
+                <TableCell>{subject.code}</TableCell>
+                <TableCell>{subject.className}</TableCell>
+                <TableCell>{subject.teacher}</TableCell>
+                <TableCell>
+                  <Badge variant={subject.isActive ? 'default' : 'destructive'}>
+                    {subject.isActive ? 'Active' : 'Inactive'}
+                  </Badge>
+                </TableCell>
+                {canManage && (
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                          <span className="sr-only">Open menu</span>
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                        <DropdownMenuItem
+                          onClick={() => router.push(`/academics/subjects/edit/${subject.id}`)}
+                        >
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleAssignTeacher(subject)}>
+                          Assign Teacher
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleDelete(subject.id)}>
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+
+      {canManage && (
+        <Dialog open={isAssignTeacherDialogOpen} onOpenChange={setIsAssignTeacherDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Assign Teacher to {selectedSubject?.name}</DialogTitle>
+            </DialogHeader>
+            <div className="py-4">
+              <Select onValueChange={setSelectedTeacher}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a teacher" />
+                </SelectTrigger>
+                <SelectContent>
+                  {teachers.map((teacher) => (
+                    <SelectItem key={teacher.id} value={teacher.id}>
+                      {teacher.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex justify-end space-x-2">
+              <Button variant="outline" onClick={() => setIsAssignTeacherDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleConfirmAssignTeacher}>Confirm</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </Card>
+  );
+};
+
+export default SubjectsList;

--- a/src/app/(dashboard)/academics/subjects/create/page.tsx
+++ b/src/app/(dashboard)/academics/subjects/create/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Switch } from '@/components/ui/switch';
+import { MultiSelect } from '@/components/ui/multi-select'; // Assuming a MultiSelect component exists
+import { subjectService } from '@/services/subjectService';
+import { schoolService } from '@/services/schoolService';
+import { classService } from '@/services/classService';
+import { toast } from 'react-hot-toast';
+
+const subjectFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  code: z.string().min(1, 'Code is required'),
+  isActive: z.boolean().default(true),
+  schoolIds: z.array(z.string()).min(1, 'At least one school is required'),
+  sectionIds: z.array(z.string()).min(1, 'At least one section is required'),
+});
+
+type SubjectFormValues = z.infer<typeof subjectFormSchema>;
+
+const CreateSubjectPage = () => {
+  const router = useRouter();
+  const [schools, setSchools] = useState([]);
+  const [sections, setSections] = useState([]);
+
+  const form = useForm<SubjectFormValues>({
+    resolver: zodResolver(subjectFormSchema),
+    defaultValues: {
+      name: '',
+      code: '',
+      isActive: true,
+      schoolIds: [],
+      sectionIds: [],
+    },
+  });
+
+  useEffect(() => {
+    const fetchSchools = async () => {
+      try {
+        const response = await schoolService.getSchools();
+        setSchools(response.data.data.map((s: any) => ({ value: s.id, label: s.name })));
+      } catch (error) {
+        toast.error('Failed to fetch schools');
+      }
+    };
+
+    const fetchClassesAndSections = async () => {
+        try {
+          const response = await classService.getClasses();
+          const allSections = response.data.flatMap((c: any) =>
+            c.sections.map((s: any) => ({ value: s.id, label: `${c.name} - ${s.name}` }))
+          );
+          setSections(allSections);
+        } catch (error) {
+          toast.error('Failed to fetch classes and sections');
+        }
+      };
+
+    fetchSchools();
+    fetchClassesAndSections();
+  }, []);
+
+  const onSubmit = async (data: SubjectFormValues) => {
+    try {
+      await subjectService.createSubject(data);
+      toast.success('Subject created successfully');
+      router.push('/academics/subjects');
+    } catch (error) {
+      toast.error('Failed to create subject');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create Subject</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., Mathematics" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="code"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Code</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., MATH101" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+                control={form.control}
+                name="schoolIds"
+                render={({ field }) => (
+                    <FormItem>
+                    <FormLabel>Schools</FormLabel>
+                    <MultiSelect
+                        options={schools}
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                        placeholder="Select schools"
+                    />
+                    <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+                control={form.control}
+                name="sectionIds"
+                render={({ field }) => (
+                    <FormItem>
+                    <FormLabel>Sections</FormLabel>
+                    <MultiSelect
+                        options={sections}
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                        placeholder="Select sections"
+                    />
+                    <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+              control={form.control}
+              name="isActive"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                  <div className="space-y-0.5">
+                    <FormLabel>Active</FormLabel>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end space-x-2">
+                <Button type="button" variant="outline" onClick={() => router.back()}>
+                    Cancel
+                </Button>
+                <Button type="submit">Create Subject</Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CreateSubjectPage;

--- a/src/app/(dashboard)/academics/subjects/edit/[id]/page.tsx
+++ b/src/app/(dashboard)/academics/subjects/edit/[id]/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Switch } from '@/components/ui/switch';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { subjectService } from '@/services/subjectService';
+import { schoolService } from '@/services/schoolService';
+import { classService } from '@/services/classService';
+import { toast } from 'react-hot-toast';
+
+const subjectFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  code: z.string().min(1, 'Code is required'),
+  isActive: z.boolean().default(true),
+  schoolIds: z.array(z.string()).min(1, 'At least one school is required'),
+  sectionIds: z.array(z.string()).min(1, 'At least one section is required'),
+});
+
+type SubjectFormValues = z.infer<typeof subjectFormSchema>;
+
+const EditSubjectPage = () => {
+  const router = useRouter();
+  const params = useParams();
+  const { id } = params;
+
+  const [subject, setSubject] = useState(null);
+  const [schools, setSchools] = useState([]);
+  const [sections, setSections] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const form = useForm<SubjectFormValues>({
+    resolver: zodResolver(subjectFormSchema),
+  });
+
+  useEffect(() => {
+    const fetchSchools = async () => {
+        try {
+          const response = await schoolService.getSchools();
+          setSchools(response.data.data.map((s: any) => ({ value: s.id, label: s.name })));
+        } catch (error) {
+          toast.error('Failed to fetch schools');
+        }
+      };
+
+      const fetchClassesAndSections = async () => {
+          try {
+            const response = await classService.getClasses();
+            const allSections = response.data.flatMap((c: any) =>
+              c.sections.map((s: any) => ({ value: s.id, label: `${c.name} - ${s.name}` }))
+            );
+            setSections(allSections);
+          } catch (error) {
+            toast.error('Failed to fetch classes and sections');
+          }
+        };
+
+      fetchSchools();
+      fetchClassesAndSections();
+  }, []);
+
+  useEffect(() => {
+    if (id) {
+      const fetchSubject = async () => {
+        try {
+          setLoading(true);
+          const response = await subjectService.getSubject(id as string);
+          setSubject(response);
+          form.reset(response);
+        } catch (error) {
+          toast.error('Failed to fetch subject');
+        } finally {
+          setLoading(false);
+        }
+      };
+      fetchSubject();
+    }
+  }, [id, form]);
+
+
+
+  const onSubmit = async (data: SubjectFormValues) => {
+    try {
+      await subjectService.updateSubject(id as string, data);
+      toast.success('Subject updated successfully');
+      router.push('/academics/subjects');
+    } catch (error) {
+      toast.error('Failed to update subject');
+    }
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Edit Subject</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., Mathematics" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="code"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Code</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., MATH101" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+                control={form.control}
+                name="schoolIds"
+                render={({ field }) => (
+                    <FormItem>
+                    <FormLabel>Schools</FormLabel>
+                    <MultiSelect
+                        options={schools}
+                        onValueChange={field.onChange}
+                        defaultValue={field.value || []}
+                        placeholder="Select schools"
+                    />
+                    <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+                control={form.control}
+                name="sectionIds"
+                render={({ field }) => (
+                    <FormItem>
+                    <FormLabel>Sections</FormLabel>
+                    <MultiSelect
+                        options={sections}
+                        onValueChange={field.onChange}
+                        defaultValue={field.value || []}
+                        placeholder="Select sections"
+                    />
+                    <FormMessage />
+                    </FormItem>
+                )}
+            />
+            <FormField
+              control={form.control}
+              name="isActive"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                  <div className="space-y-0.5">
+                    <FormLabel>Active</FormLabel>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end space-x-2">
+                <Button type="button" variant="outline" onClick={() => router.back()}>
+                    Cancel
+                </Button>
+                <Button type="submit">Save Changes</Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default EditSubjectPage;

--- a/src/app/(dashboard)/academics/subjects/page.tsx
+++ b/src/app/(dashboard)/academics/subjects/page.tsx
@@ -2,12 +2,12 @@
 
 import withAuth from '@/components/withAuth';
 import { STAFF_ROLES } from '@/constants/roles';
+import SubjectsList from './SubjectsList';
 
 const SubjectsPage = () => {
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold">Subjects</h1>
-      <p>This page is currently under construction. Please check back later.</p>
+      <SubjectsList />
     </div>
   );
 };

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import { Command as CommandPrimitive } from "cmdk";
+
+type Option = Record<"value" | "label", string>;
+
+export function MultiSelect({
+    options,
+    onValueChange,
+    defaultValue,
+    placeholder = "Select options"
+}: {
+    options: Option[],
+    onValueChange: (value: string[]) => void,
+    defaultValue: string[],
+    placeholder?: string
+}) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [open, setOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<Option[]>(
+    defaultValue.map(value => options.find(option => option.value === value)).filter(Boolean) as Option[]
+  );
+  const [inputValue, setInputValue] = React.useState("");
+
+  React.useEffect(() => {
+    onValueChange(selected.map(s => s.value));
+  }, [selected]);
+
+  const handleUnselect = React.useCallback((option: Option) => {
+    setSelected(prev => prev.filter(s => s.value !== option.value));
+  }, []);
+
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const input = inputRef.current
+    if (input) {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (input.value === "") {
+          setSelected(prev => {
+            const newSelected = [...prev];
+            newSelected.pop();
+            return newSelected;
+          })
+        }
+      }
+      if (e.key === "Escape") {
+        input.blur();
+      }
+    }
+  }, []);
+
+  const selectables = options.filter(option => !selected.some(s => s.value === option.value));
+
+  return (
+    <Command onKeyDown={handleKeyDown} className="overflow-visible bg-transparent">
+      <div
+        className="group border border-input px-3 py-2 text-sm ring-offset-background rounded-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+      >
+        <div className="flex gap-1 flex-wrap">
+          {selected.map((option) => {
+            return (
+              <Badge key={option.value} variant="secondary">
+                {option.label}
+                <button
+                  className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleUnselect(option);
+                    }
+                  }}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={() => handleUnselect(option)}
+                >
+                  <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                </button>
+              </Badge>
+            )
+          })}
+          <CommandPrimitive.Input
+            ref={inputRef}
+            value={inputValue}
+            onValueChange={setInputValue}
+            onBlur={() => setOpen(false)}
+            onFocus={() => setOpen(true)}
+            placeholder={placeholder}
+            className="ml-2 bg-transparent outline-none placeholder:text-muted-foreground flex-1"
+          />
+        </div>
+      </div>
+      <div className="relative mt-2">
+        {open && selectables.length > 0 ?
+          <div className="absolute w-full z-10 top-0 rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
+            <CommandGroup className="h-full overflow-auto">
+              {selectables.map((option) => {
+                return (
+                  <CommandItem
+                    key={option.value}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    onSelect={() => {
+                      setInputValue("")
+                      setSelected(prev => [...prev, option])
+                    }}
+                    className={"cursor-pointer"}
+                  >
+                    {option.label}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </div>
+          : null}
+      </div>
+    </Command >
+  )
+}

--- a/src/services/subjectService.ts
+++ b/src/services/subjectService.ts
@@ -1,0 +1,100 @@
+import { UserRole } from '@/constants/roles';
+import { get, post, put, del } from '@/utils/api';
+
+export interface Subject {
+  id: string;
+  name: string;
+  code: string;
+  className: string;
+  teacher: string;
+  isActive: boolean;
+  schoolIds: string[];
+  sectionIds: string[];
+}
+
+export interface Teacher {
+  id: string;
+  name: string;
+}
+
+
+const BASE_URL = '/subjects';
+
+export const subjectService = {
+  getSubjects: async (filters = {}): Promise<any> => {
+    // const query = new URLSearchParams(filters).toString();
+    // return get(`${BASE_URL}?${query}`);
+    // Mocked response
+    console.log('Fetching subjects with filters:', filters);
+    return Promise.resolve({
+        totalItems: 3,
+        totalPages: 1,
+        currentPage: 1,
+        prevPage: null,
+        nextPage: null,
+        itemPerPage: 10,
+        data: [
+            { id: '1', name: 'Mathematics', code: 'MATH101', className: 'Grade 10', teacher: 'Mr. Smith', isActive: true },
+            { id: '2', name: 'Science', code: 'SCI101', className: 'Grade 10', teacher: 'Ms. Jones', isActive: true },
+            { id: '3', name: 'History', code: 'HIST101', className: 'Grade 10', teacher: 'Mr. Doe', isActive: false },
+        ]
+    });
+  },
+
+  getSubject: async (id: string): Promise<any> => {
+    // return get(`${BASE_URL}/${id}`);
+    // Mocked response
+    console.log(`Fetching subject with id: ${id}`);
+    return Promise.resolve({
+        id: '1', name: 'Mathematics', code: 'MATH101', className: 'Grade 10', teacher: 'Mr. Smith', isActive: true, schoolIds: ['school1'], sectionIds: ['section1']
+    });
+  },
+
+  createSubject: async (data: Partial<Subject>): Promise<any> => {
+    // return post(BASE_URL, data);
+    // Mocked response
+    console.log('Creating subject with data:', data);
+    return Promise.resolve({ id: '4', ...data });
+  },
+
+  updateSubject: async (id: string, data: Partial<Subject>): Promise<any> => {
+    // return put(`${BASE_URL}/${id}`, data);
+    // Mocked response
+    console.log(`Updating subject ${id} with data:`, data);
+    return Promise.resolve({ id, ...data });
+  },
+
+  deleteSubject: async (id: string): Promise<any> => {
+    // return del(`${BASE_URL}/${id}`);
+    // Mocked response
+    console.log(`Deleting subject with id: ${id}`);
+    return Promise.resolve();
+  },
+
+  assignTeacher: async (subjectId: string, teacherId: string): Promise<any> => {
+    // return put(`${BASE_URL}/${subjectId}/teacher`, { teacherId });
+    // Mocked response
+    console.log(`Assigning teacher ${teacherId} to subject ${subjectId}`);
+    return Promise.resolve();
+  },
+};
+
+export const staffService = {
+    getAllStaff: async (): Promise<any> => {
+        // return get('/staff');
+        // Mocked response
+        return Promise.resolve({
+            totalItems: 3,
+            totalPages: 1,
+            currentPage: 1,
+            prevPage: null,
+            nextPage: null,
+            itemPerPage: 10,
+            data: [
+                { id: '1', name: 'Mr. Smith', user: { role: UserRole.TEACHER } },
+                { id: '2', name: 'Ms. Jones', user: { role: UserRole.TEACHER } },
+                { id: '3', name: 'Mr. Doe', user: { role: UserRole.TEACHER } },
+            ]
+        });
+    }
+}


### PR DESCRIPTION
This commit introduces the user interface for managing subjects within the academics section of the application.

It includes the following features:
- A list view for subjects with columns for Name, Code, Class, Teacher, and Status.
- A form for creating new subjects with fields for name, code, active status, and assignments to schools and sections.
- A form for editing existing subjects, pre-filled with the subject's data.
- A dialog for assigning a teacher to a subject.
- Role-based access control to ensure that only authorized users (Super Admins and Admins) can perform management actions like creating, editing, deleting, and assigning subjects.

A reusable MultiSelect component has been created to handle the selection of multiple schools and sections.

The implementation uses mocked services for API interactions, as the backend will be handled separately.